### PR TITLE
tutorial/toh-pt6の修正

### DIFF
--- a/aio-ja/content/examples/toh-pt6/src/app/hero.service.ts
+++ b/aio-ja/content/examples/toh-pt6/src/app/hero.service.ts
@@ -50,12 +50,12 @@ export class HeroService {
   // #enddocregion getHeroes, getHeroes-1, getHeroes-2
 
   // #docregion getHeroNo404
-  /** IDによりヒーローを取得. idが見つからない場合は`undefined`を返す */
+  /** IDによりヒーローを取得する。idが見つからない場合は`undefined`を返す。 */
   getHeroNo404<Data>(id: number): Observable<Hero> {
     const url = `${this.heroesUrl}/?id=${id}`;
     return this.http.get<Hero[]>(url)
       .pipe(
-        map(heroes => heroes[0]), // returns a {0|1} element array
+        map(heroes => heroes[0]), // {0|1} 要素の配列を返す
         // #enddocregion getHeroNo404
         tap(h => {
           const outcome = h ? `fetched` : `did not find`;
@@ -68,7 +68,7 @@ export class HeroService {
   // #enddocregion getHeroNo404
 
   // #docregion getHero
-  /** IDによりヒーローを取得。見つからなかった場合は404を返却 */
+  /** IDによりヒーローを取得する。見つからなかった場合は404を返却する。 */
   getHero(id: number): Observable<Hero> {
     const url = `${this.heroesUrl}/${id}`;
     return this.http.get<Hero>(url).pipe(
@@ -129,7 +129,7 @@ export class HeroService {
 
   // #docregion handleError
   /**
-   * 失敗したHttp操作を処理します
+   * 失敗したHttp操作を処理します。
    * アプリを持続させます。
    * @param operation - 失敗した操作の名前
    * @param result - observableな結果として返す任意の値

--- a/aio-ja/content/tutorial/toh-pt6.md
+++ b/aio-ja/content/tutorial/toh-pt6.md
@@ -506,6 +506,7 @@ CLIは`HeroSearchComponent`を作成し、`AppModule`のdeclarationsにそのコ
 
 <div class="l-sub-section">
   
+
   [switchMap operator](http://www.learnrxjs.io/operators/transformation/switchmap.html)により
   すべての適格なキーイベントが`HttpClient.get`メソッドを呼び出すことができます。
   各リクエスト間の300msの休止により、複数のHTTPリクエストを送信できますが、それらは順序どおりに戻ってこないかもしれません。


### PR DESCRIPTION
tutorial/toh-pt6を修正しました。レビューお願いします。

修正内容は下記のとおりです。

* `switchMap operator` から始まるパラグラフでマークダウンが反映されていなかったので、空行を追加してリンクとして反映されるように
* `hero.service.ts`が正しいディレクトリになかったので移動 (とコメントの文言微調整)

Close #81 