### PR TITLE
translate(content): unify name of index to 'Angular Service Worker'

### DIFF
--- a/aio-ja/content/guide/service-worker-intro.md
+++ b/aio-ja/content/guide/service-worker-intro.md
@@ -31,7 +31,7 @@ AngularにおけるService Workerのインストールは、`NgModule`に含め�
 
 ## 前提条件
 
-AngularにおけるService Workerを使用するために、次のAngularとCLIのバージョンが必要です。
+Angular Service Workerを使用するために、次のAngularとCLIのバージョンが必要です。
 
 * Angular 5.0.0 以上
 * Angular CLI 1.6.0 以上
@@ -46,7 +46,7 @@ Service Workerの一般的な情報については、[Service Workerの紹介](h
 
 このドキュメンテーションの続きでは、Service WorkerをAngularに実装することに取り組みます。
 
-## もっとAngularにおけるService Workerを知りたい
+## もっとAngular Service Workerを知りたい
 
 次の記事がお勧めです。
 * [Service Workerを始める](guide/service-worker-getting-started)


### PR DESCRIPTION
to fix #97

1ページ目も最後の「次の紹介記述」を統一しました。

見出し「AngularにおけるService Worker」のセクションはそのままにしています。一般的なService WorkerとAngular Serivce Workerを区別して説明しているところなので、今の方が明快で読み易いと思ったからです。
  