### PR TITLE
guide/observables.md の翻訳

### DIFF
--- a/aio-ja/content/guide/observables.md
+++ b/aio-ja/content/guide/observables.md
@@ -71,7 +71,7 @@ Observableの通知を受け取るハンドラーは、`Observer` インター�
 
 <code-example path="observables/src/creating.ts" region="fromevent" header="Create with custom fromEvent function"></code-example>
 
-Now you can use this function to create an observable that publishes keydown events:
+この関数を利用して、イベント`keydown`を公開するObservableを作成できます。:
 
 <code-example path="observables/src/creating.ts" region="fromevent_use" header="Use custom fromEvent function"></code-example>
 

--- a/aio-ja/content/guide/observables.md
+++ b/aio-ja/content/guide/observables.md
@@ -67,11 +67,11 @@ Observableの通知を受け取るハンドラーは、`Observer` インター�
 
 <code-example path="observables/src/creating.ts" region="subscriber" header="Create observable with constructor"></code-example>
 
-この例を少しステップアップすると、イベントを公開するObservableを作成できます。この例では、サブスクライバー関数はインラインで定義されています。
+この例を少しステップアップすると、イベントをパブリッシュするObservableを作成できます。この例では、サブスクライバー関数はインラインで定義されています。
 
 <code-example path="observables/src/creating.ts" region="fromevent" header="Create with custom fromEvent function"></code-example>
 
-この関数を利用して、イベント`keydown`を公開するObservableを作成できます。:
+この関数を利用して、イベント`keydown`をパブリッシュするObservableを作成できます。:
 
 <code-example path="observables/src/creating.ts" region="fromevent_use" header="Use custom fromEvent function"></code-example>
 


### PR DESCRIPTION
refs: #346

一行だけ英文が残っていたので翻訳しました

文中でpublishの翻訳に表記ゆれがあり、
公開する、パブリッシュする、購読する
といった表記で迷いましたが、直前で`公開する`となっていたのでそれに合わせました。

