### PR TITLE
fix: guide/aot-compiler: 軽微な修正

### DIFF
--- a/aio-ja/content/guide/aot-compiler.md
+++ b/aio-ja/content/guide/aot-compiler.md
@@ -105,7 +105,7 @@ export class TypicalComponent {
 }
 ```
 
-Angular コンパイラはメタデータ _once_ を抽出し、 `TypicalComponent` に対して _factory_ を生成します。
+Angular コンパイラはメタデータを _1回_ 抽出し、 `TypicalComponent` に対して _factory_ を生成します。
 `TypicalComponent` インスタンスを作成する必要があるとき、Angular はファクトリを呼び出します。ファクトリは注入された依存関係をもつコンポーネントクラスの新しいインスタンスにバインドされた新しいビジュアル要素を生成します。
 
 ## メタデータの制限


### PR DESCRIPTION
- fix: _once_ -> 一回

`once` というメタデータがあるわけではなく、単純に"ファクトリ作る前に1回抽出するよ"という意味ではないでしょうか。やるとしたら別コミットにしようと思いますが、次の文では factory はファクトリとして訳されているため、_factory_ は _ファクトリ_ でも良さそうでしょうか。