### PR TITLE
イベントを新しいものから並べるようにしました

### DIFF
--- a/aio-ja/content/marketing/events.html
+++ b/aio-ja/content/marketing/events.html
@@ -20,142 +20,30 @@
     <tbody>
       <tr>
         <td>
-          <a href="https://ng-kobe.connpass.com/event/86926/" target="_blank" rel="noopener">第６回：Angular もくもく会</a>
+          <a href="https://ngjapan.org/" target="_blank" rel="noopener">ng-japan 2019</a>
         </td>
-        <td>2018/05/26</td>
-        <td>神戸</td>
-      </tr>
-      <tr>
-        <td>
-          <a href="https://ngjapan.org/" target="_blank" rel="noopener">ng-japan 2018</a>
-        </td>
-        <td>2018/06/16</td>
+        <td>2019/07/13</td>
         <td>東京</td>
       </tr>
       <tr>
         <td>
-          <a href="https://ng-kobe.connpass.com/event/89603/" target="_blank" rel="noopener">第７回：Angular もくもく会</a>
+          <a href="https://ng-gunma.connpass.com/event/122833/" target="_blank" rel="noopener">第5回：Angular もくもく会@グンマー</a>
         </td>
-        <td>2018/07/07</td>
-        <td>神戸</td>
-      </tr>
-      <tr>
-        <td>
-          <a href="https://ngjapan.connpass.com/event/88672/" target="_blank" rel="noopener">Angular MokuMoku Night #1</a>
-        </td>
-        <td>2018/07/09</td>
-        <td>東京</td>
-      </tr>
-      <tr>
-        <td>
-          <a href="https://ngjapan.connpass.com/event/88680/" target="_blank" rel="noopener">Angular MokuMoku Night #2</a>
-        </td>
-        <td>2018/07/25</td>
-        <td>東京</td>
-      </tr>
-      <tr>
-        <td>
-          <a href="https://ng-fukuoka.connpass.com/event/100607/" target="_blank" rel="noopener">Angular触ろうの会 in Fukuoka #6</a>
-        </td>
-        <td>2018/09/27</td>
-        <td>福岡</td>
-      </tr>
-      <tr>
-        <td>
-          <a href="https://ng-kobe.connpass.com/event/100849/" target="_blank" rel="noopener">第8回：Angular もくもく会</a>
-        </td>
-        <td>2018/09/29</td>
-        <td>神戸</td>
-      </tr>
-      <tr>
-        <td>
-          <a href="https://ng-gunma.connpass.com/event/101008/" target="_blank" rel="noopener">第1回：Angular もくもく会@グンマー</a>
-        </td>
-        <td>2018/09/29</td>
+        <td>2019/04/06</td>
         <td>群馬</td>
       </tr>
       <tr>
         <td>
-          <a href="https://ng-kyoto.connpass.com/event/100685/" target="_blank" rel="noopener">ng-kyoto Angular Meetup #8</a>
+          <a href="https://ng-fukuoka.connpass.com/event/124284/" target="_blank" rel="noopener">Angular もくもく会 in Fukuoka #8</a>
         </td>
-        <td>2018/10/06</td>
-        <td>大阪</td>
-      </tr>
-      <tr>
-        <td>
-          <a href="https://ng-kobe.connpass.com/event/103431/" target="_blank" rel="noopener">第9回：Angular もくもく会</a>
-        </td>
-        <td>2018/10/27</td>
-        <td>神戸</td>
-      </tr>
-      <tr>
-        <td>
-          <a href="https://ng-fukuoka.connpass.com/event/106685/" target="_blank" rel="noopener">Angular触ろうの会 in Fukuoka #7</a>
-        </td>
-        <td>2018/11/09</td>
+        <td>2019/03/28</td>
         <td>福岡</td>
       </tr>
       <tr>
         <td>
-          <a href="https://ng-kobe.connpass.com/event/107565/" target="_blank" rel="noopener">第10回：Angular もくもく会</a>
+          <a href="https://classi-angular-night.connpass.com/event/121367/" target="_blank" rel="noopener">Classi Angular Night #2</a>
         </td>
-        <td>2018/11/24</td>
-        <td>神戸</td>
-      </tr>
-      <tr>
-        <td>
-          <a href="https://ngjapan.connpass.com/event/100792/" target="_blank" rel="noopener">Angular MokuMoku Night #4</a>
-        </td>
-        <td>2018/11/28</td>
-        <td>東京</td>
-      </tr>
-      <tr>
-        <td>
-          <a href="https://ng-gunma.connpass.com/event/107674/" target="_blank" rel="noopener">第2回：Angular もくもく会@グンマー</a>
-        </td>
-        <td>2018/12/01</td>
-        <td>群馬</td>
-      </tr>
-      <tr>
-        <td>
-          <a href="https://ng-sake.connpass.com/event/109138/" target="_blank" rel="noopener">ng-sake #13 Angular忘年会</a>
-        </td>
-        <td>2018/12/13</td>
-        <td>東京</td>
-      </tr>
-      <tr>
-        <td>
-          <a href="https://ngjapan.connpass.com/event/113268/" target="_blank" rel="noopener">Angular MokuMoku Night #5</a>
-        </td>
-        <td>2019/01/16</td>
-        <td>東京</td>
-      </tr>
-      <tr>
-        <td>
-          <a href="https://ng-kyoto.connpass.com/event/113358/" target="_blank" rel="noopener">ng-kyoto Angular Meetup #9</a>
-        </td>
-        <td>2019/01/18</td>
-        <td>大阪</td>
-      </tr>
-      <tr>
-        <td>
-          <a href="https://ionic-jp.connpass.com/event/111912/" target="_blank" rel="noopener">Angular & Ionic Meetup Fukuoka</a>
-        </td>
-        <td>2019/01/19</td>
-        <td>福岡</td>
-      </tr>
-      <tr>
-        <td>
-          <a href="https://ng-gunma.connpass.com/event/113161/" target="_blank" rel="noopener">第3回：Angular もくもく会@グンマー</a>
-        </td>
-        <td>2019/01/26</td>
-        <td>群馬</td>
-      </tr>
-      <tr>
-        <td>
-          <a href="https://classi-angular-night.connpass.com/event/112186/" target="_blank" rel="noopener">Classi Angular Night #1</a>
-        </td>
-        <td>2019/01/31</td>
+        <td>2019/03/27</td>
         <td>東京</td>
       </tr>
       <tr>
@@ -167,31 +55,143 @@
       </tr>
       <tr>
         <td>
-          <a href="https://classi-angular-night.connpass.com/event/121367/" target="_blank" rel="noopener">Classi Angular Night #2</a>
+          <a href="https://classi-angular-night.connpass.com/event/112186/" target="_blank" rel="noopener">Classi Angular Night #1</a>
         </td>
-        <td>2019/03/27</td>
+        <td>2019/01/31</td>
         <td>東京</td>
       </tr>
       <tr>
         <td>
-          <a href="https://ng-fukuoka.connpass.com/event/124284/" target="_blank" rel="noopener">Angular もくもく会 in Fukuoka #8</a>
+          <a href="https://ng-gunma.connpass.com/event/113161/" target="_blank" rel="noopener">第3回：Angular もくもく会@グンマー</a>
         </td>
-        <td>2019/03/28</td>
-        <td>福岡</td>
-      </tr>
-      <tr>
-        <td>
-          <a href="https://ng-gunma.connpass.com/event/122833/" target="_blank" rel="noopener">第5回：Angular もくもく会@グンマー</a>
-        </td>
-        <td>2019/04/06</td>
+        <td>2019/01/26</td>
         <td>群馬</td>
       </tr>
       <tr>
         <td>
-          <a href="https://ngjapan.org/" target="_blank" rel="noopener">ng-japan 2019</a>
+          <a href="https://ionic-jp.connpass.com/event/111912/" target="_blank" rel="noopener">Angular & Ionic Meetup Fukuoka</a>
         </td>
-        <td>2019/07/13</td>
+        <td>2019/01/19</td>
+        <td>福岡</td>
+      </tr>
+      <tr>
+        <td>
+          <a href="https://ng-kyoto.connpass.com/event/113358/" target="_blank" rel="noopener">ng-kyoto Angular Meetup #9</a>
+        </td>
+        <td>2019/01/18</td>
+        <td>大阪</td>
+      </tr>
+      <tr>
+        <td>
+          <a href="https://ngjapan.connpass.com/event/113268/" target="_blank" rel="noopener">Angular MokuMoku Night #5</a>
+        </td>
+        <td>2019/01/16</td>
         <td>東京</td>
+      </tr>
+      <tr>
+        <td>
+          <a href="https://ng-sake.connpass.com/event/109138/" target="_blank" rel="noopener">ng-sake #13 Angular忘年会</a>
+        </td>
+        <td>2018/12/13</td>
+        <td>東京</td>
+      </tr>
+      <tr>
+        <td>
+          <a href="https://ng-gunma.connpass.com/event/107674/" target="_blank" rel="noopener">第2回：Angular もくもく会@グンマー</a>
+        </td>
+        <td>2018/12/01</td>
+        <td>群馬</td>
+      </tr>
+      <tr>
+        <td>
+          <a href="https://ngjapan.connpass.com/event/100792/" target="_blank" rel="noopener">Angular MokuMoku Night #4</a>
+        </td>
+        <td>2018/11/28</td>
+        <td>東京</td>
+      </tr>
+      <tr>
+        <td>
+          <a href="https://ng-kobe.connpass.com/event/107565/" target="_blank" rel="noopener">第10回：Angular もくもく会</a>
+        </td>
+        <td>2018/11/24</td>
+        <td>神戸</td>
+      </tr>
+      <tr>
+        <td>
+          <a href="https://ng-fukuoka.connpass.com/event/106685/" target="_blank" rel="noopener">Angular触ろうの会 in Fukuoka #7</a>
+        </td>
+        <td>2018/11/09</td>
+        <td>福岡</td>
+      </tr>
+      <tr>
+        <td>
+          <a href="https://ng-kobe.connpass.com/event/103431/" target="_blank" rel="noopener">第9回：Angular もくもく会</a>
+        </td>
+        <td>2018/10/27</td>
+        <td>神戸</td>
+      </tr>
+      <tr>
+        <td>
+          <a href="https://ng-kyoto.connpass.com/event/100685/" target="_blank" rel="noopener">ng-kyoto Angular Meetup #8</a>
+        </td>
+        <td>2018/10/06</td>
+        <td>大阪</td>
+      </tr>
+      <tr>
+        <td>
+          <a href="https://ng-gunma.connpass.com/event/101008/" target="_blank" rel="noopener">第1回：Angular もくもく会@グンマー</a>
+        </td>
+        <td>2018/09/29</td>
+        <td>群馬</td>
+      </tr>
+      <tr>
+        <td>
+          <a href="https://ng-kobe.connpass.com/event/100849/" target="_blank" rel="noopener">第8回：Angular もくもく会</a>
+        </td>
+        <td>2018/09/29</td>
+        <td>神戸</td>
+      </tr>
+      <tr>
+        <td>
+          <a href="https://ng-fukuoka.connpass.com/event/100607/" target="_blank" rel="noopener">Angular触ろうの会 in Fukuoka #6</a>
+        </td>
+        <td>2018/09/27</td>
+        <td>福岡</td>
+      </tr>
+      <tr>
+        <td>
+          <a href="https://ngjapan.connpass.com/event/88680/" target="_blank" rel="noopener">Angular MokuMoku Night #2</a>
+        </td>
+        <td>2018/07/25</td>
+        <td>東京</td>
+      </tr>
+      <tr>
+        <td>
+          <a href="https://ngjapan.connpass.com/event/88672/" target="_blank" rel="noopener">Angular MokuMoku Night #1</a>
+        </td>
+        <td>2018/07/09</td>
+        <td>東京</td>
+      </tr>
+      <tr>
+        <td>
+          <a href="https://ng-kobe.connpass.com/event/89603/" target="_blank" rel="noopener">第７回：Angular もくもく会</a>
+        </td>
+        <td>2018/07/07</td>
+        <td>神戸</td>
+      </tr>
+      <tr>
+        <td>
+          <a href="https://ngjapan.org/" target="_blank" rel="noopener">ng-japan 2018</a>
+        </td>
+        <td>2018/06/16</td>
+        <td>東京</td>
+      </tr>
+      <tr>
+        <td>
+          <a href="https://ng-kobe.connpass.com/event/86926/" target="_blank" rel="noopener">第６回：Angular もくもく会</a>
+        </td>
+        <td>2018/05/26</td>
+        <td>神戸</td>
       </tr>
     </tbody>
   </table>


### PR DESCRIPTION
`https://angular.jp/events` からイベントを調べようとする人たちは、古いイベントより新しいイベントのことを知りたいと思うので、イベントを新しいものから並べ替えてみましたがいかがでしょうか？

不要であれば PR を削除いただければと思います。