### PR TITLE
英語表記が残っていたので削除

### DIFF
--- a/aio-ja/content/tutorial/toh-pt5.md
+++ b/aio-ja/content/tutorial/toh-pt5.md
@@ -54,7 +54,6 @@ CLIを使って生成することができます。
 *ルート*は、ユーザーがリンクをクリックしたとき、またはURLをブラウザのアドレスバーに貼り付けたときに、
 どのビューを表示したらよいかをルーターに伝えます。
 
-Since `AppRoutingModule` already imports `HeroesComponent`, you can use it in the `routes` array:
 `AppRoutingModule` はすでに `HeroesComponent` をインポートしているため、 `routes` 配列で使用できます。
 
 <code-example path="toh-pt5/src/app/app-routing.module.ts" header="src/app/app-routing.module.ts"


### PR DESCRIPTION
以下の英語表記が残っていた（日本語と併記されていた）ので削除しました。
"Since AppRoutingModule already imports HeroesComponent, you can use it in the routes array:"

## 翻訳・修正

- [x] 変更内容は[CONTRIBUTING.md](https://github.com/angular/angular-ja/blob/master/CONTRIBUTING.md) に記載されたワークフローに従っています

## 関連Issue

<!-- 関連Issueがあれば記載してください -->


### 備考
<!-- 重点的にレビューしてほしい部分などあれば自由に記入してください -->
