### PR TITLE
Fix missing closing tag for `<code-example>` in `tutorial/toh-pt5`

### DIFF
--- a/aio-ja/content/tutorial/toh-pt5.md
+++ b/aio-ja/content/tutorial/toh-pt5.md
@@ -63,6 +63,7 @@ CLIを使って生成することができます。
 `AppRoutingModule` はすでに `HeroesComponent` をインポートしているため、 `routes` 配列で使用できます。
 
 <code-example path="toh-pt5/src/app/app-routing.module.ts" header="src/app/app-routing.module.ts"
+  region="heroes-route">
 </code-example>
 
 典型的なAngularの`Route`はふたつのプロパティを持っています：


### PR DESCRIPTION
Missing closing tag for `<code-example>` is causing code block disappeared.
Fix this by adding closing tag in reference of the original source.
![](https://gyazo.com/07ac8792fbcd96c340e0d7ee899f5774.png)

## 翻訳・修正

- [x] 変更内容は[CONTRIBUTING.md](https://github.com/angular/angular-ja/blob/master/CONTRIBUTING.md) に記載されたワークフローに従っています

## 関連Issue

<!-- 関連Issueがあれば記載してください -->


### 備考
<!-- 重点的にレビューしてほしい部分などあれば自由に記入してください -->
