### PR TITLE
Fix typo in docs

### DIFF
--- a/aio-ja/content/guide/lifecycle-hooks.md
+++ b/aio-ja/content/guide/lifecycle-hooks.md
@@ -162,7 +162,7 @@ Angular は次のシーケンスでフックメソッドを実行します。 �
 
     <td>
 
-      `ngAfterViewInit()` およびその後のすべての `ngAfterContentChecke()` の後に呼び出されます。
+      `ngAfterViewInit()` およびその後のすべての `ngAfterContentChecked()` の後に呼び出されます。
 
     </td>
   </tr>


### PR DESCRIPTION
Fix typo `ngAfterContentChecke` to `ngAfterContentChecked` at line 165 in lifecycle-hooks.md

165行目について `ngAfterContentChecke()`は `ngAfterContentChecked()`  が正しいかと思います。

## 翻訳・修正

- [x] 変更内容は[CONTRIBUTING.md](https://github.com/angular/angular-ja/blob/master/CONTRIBUTING.md) に記載されたワークフローに従っています

## 関連Issue

<!-- 関連Issueがあれば記載してください -->


### 備考
<!-- 重点的にレビューしてほしい部分などあれば自由に記入してください -->
