### PR TITLE
Getting StartedのStackBlitzのサンプルのリンクが設定されていない

### DIFF
--- a/aio-ja/content/start/index.md
+++ b/aio-ja/content/start/index.md
@@ -49,7 +49,7 @@ Angularアプリケーションはコンポーネントを使って構築しま�
 
 ## Create the sample project
 
-サンプルプロジェクトを作成するには、<live-example name="get-started-v0" noDownload>既製のサンプルプロジェクトをStackBlitz</live-example>で生成します。
+サンプルプロジェクトを作成するには、<live-example name="get-started-v0" noDownload>[既製のサンプルプロジェクトをStackBlitz](https://stackblitz.com/angular/kgykqgaqokg?file=src%2Fapp%2Fapp.component.ts)</live-example>で生成します。
 作業を保存するには
 
 1. StackBlitzにログインします。

--- a/aio-ja/content/start/index.md
+++ b/aio-ja/content/start/index.md
@@ -49,7 +49,7 @@ Angularアプリケーションはコンポーネントを使って構築しま�
 
 ## Create the sample project
 
-サンプルプロジェクトを作成するには、<live-example name="get-started-v0" noDownload>[既製のサンプルプロジェクトをStackBlitz](https://stackblitz.com/angular/kgykqgaqokg?file=src%2Fapp%2Fapp.component.ts)</live-example>で生成します。
+サンプルプロジェクトを作成するには、<live-example name="getting-started-v0" noDownload>既製のサンプルプロジェクトをStackBlitz</live-example>で生成します。
 作業を保存するには
 
 1. StackBlitzにログインします。


### PR DESCRIPTION
AngularのGetting Startedをやってみたところ、StackBlitzのサンプルが開きませんでした。
live-exampleのタグは残したままで良いのかなど、修正が曖昧で申し訳ありません。
初心者からするとサンプルがすぐ開けた方が勉強しやすいかなと思うので、ご検討よろしくお願い致します（本家のドキュメントではリンクで開けました）。

## 翻訳・修正

- [x] 変更内容は[CONTRIBUTING.md](https://github.com/angular/angular-ja/blob/master/CONTRIBUTING.md) に記載されたワークフローに従っています

## 関連Issue

<!-- 関連Issueがあれば記載してください -->


### 備考
<!-- 重点的にレビューしてほしい部分などあれば自由に記入してください -->
