### PR TITLE
環境変数追加(NFS用): chokidarのusePolling

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,3 +19,5 @@ services:
     volumes: 
       - ./aio-ja:/aio-ja
       - ./scripts:/scripts
+    environment:
+      CHOKIDAR_USEPOLLING: ${CHOKIDAR_USEPOLLING:-false}


### PR DESCRIPTION
## docker-compose.ymlに環境変数追加

- [x] 変更内容は[CONTRIBUTING.md](https://github.com/angular/angular-ja/blob/master/CONTRIBUTING.md) に記載されたワークフローに従っています

docker-compose環境への変更、お疲れ様でした。

NFSでマウントしている等の環境では、自動の再ビルドが行われないようです。(NFSか否かの違いだけで確認しています)

chokidarの`usePolling`オプションに対応する環境変数`CHOKIDAR_USEPOLLING`を`true`に変更すると、自動の再ビルドが機能しました。

https://github.com/paulmillr/chokidar#performance
https://nodejs.org/dist/latest-v14.x/docs/api/fs.html#fs_availability

- 無関係の環境では、パフォーマンス的にデフォルト`false`のままが良いようです
 
差し支えなければ、dockerに環境変数を渡せるようにYAML変更すると、下記のように実行できて便利です。

```bash
export CHOKIDAR_USEPOLLING=true
yarn start
```

ご検討よろしくお願いいたします。