### PR TITLE
子コンポーネントにデータを渡すの章で説明が抜けているためエラーが起こる (英語のドキュメントと比較)

### DIFF
--- a/aio-ja/content/start/index.md
+++ b/aio-ja/content/start/index.md
@@ -199,7 +199,7 @@ StackBlitzの使い方については、[StackBlitz documentation](https://devel
 
   <code-example header="src/app/product-alerts/product-alerts.component.html" path="getting-started/src/app/product-alerts/product-alerts.component.1.html"></code-example>
   
-1. `ProductAlertsComponent`を他のコンポーネント内でも使えるように、 `app.module.ts`内の`AppModule's　declarations`に追加する。
+1. `ProductAlertsComponent`を他のコンポーネント内でも使えるように、 `app.module.ts`内の`AppModule`の　`declarations`に追加する。
 
   <code-example header="src/app/app.module.ts" path="getting-started/src/app/app.module.ts" region="declare-product-alerts"></code-example>
 

--- a/aio-ja/content/start/index.md
+++ b/aio-ja/content/start/index.md
@@ -198,6 +198,10 @@ StackBlitzの使い方については、[StackBlitz documentation](https://devel
 1. `product-alerts.component.html`を開き、プレースホルダの段落を、製品価格が$700以上の場合に表示される**Notify Me**ボタンに置き換えます。
 
   <code-example header="src/app/product-alerts/product-alerts.component.html" path="getting-started/src/app/product-alerts/product-alerts.component.1.html"></code-example>
+  
+1. `ProductAlertsComponent`を他のコンポーネント内でも使えるように、 `app.module.ts`内の`AppModule's　declarations`に追加する。
+
+  <code-example header="src/app/app.module.ts" path="getting-started/src/app/app.module.ts" region="declare-product-alerts"></code-example>
 
 1. `ProductListComponent` の子として `ProductAlertsComponent` を表示するには、`product-list.component.html` にセレクター `<app-product-alerts>` を追加します。
   プロパティバインディングを使用して、現在の製品を入力としてコンポーネントに渡します。


### PR DESCRIPTION
修正箇所：
https://angular.jp/start#%E5%AD%90%E3%82%B3%E3%83%B3%E3%83%9D%E3%83%BC%E3%83%8D%E3%83%B3%E3%83%88%E3%81%AB%E3%83%87%E3%83%BC%E3%82%BF%E3%82%92%E6%B8%A1%E3%81%99

原文：
To make ProductAlertsComponent available to other components in the application, add it to AppModule's declarations in app.module.ts.
↓
日本語翻訳 (間違っていたり読みづらければ、修正お願いいたします)：
`ProductAlertsComponent`を他のコンポーネント内でも使えるように、 `app.module.ts`内の`AppModule's　declarations`に追加する。

エラー内容：
```
'app-product-alerts' is not a known element:

If 'app-product-alerts' is an Angular component, then verify that it is part of this module.
If 'app-product-alerts' is a Web Component then add 'CUSTOM_ELEMENTS_SCHEMA' to the '@NgModule.schemas' of this component to suppress this message.
```

## 翻訳・修正

- [x] 変更内容は[CONTRIBUTING.md](https://github.com/angular/angular-ja/blob/master/CONTRIBUTING.md) に記載されたワークフローに従っています

## 関連Issue

<!-- 関連Issueがあれば記載してください -->


### 備考
<!-- 重点的にレビューしてほしい部分などあれば自由に記入してください -->
