### PR TITLE
chore: use temporal angular/docs version patch to extract header id

### DIFF
--- a/tools/adev-patches/resolve-angular-docs-build-version.patch
+++ b/tools/adev-patches/resolve-angular-docs-build-version.patch
@@ -1,0 +1,61 @@
+diff --git a/package.json b/package.json
+index af4c06c298..104460fe9d 100644
+--- a/package.json
++++ b/package.json
+@@ -158,7 +158,7 @@
+     "@angular-devkit/architect-cli": "^0.1801.0-next",
+     "@angular/animations": "^18.1.0-next",
+     "@angular/build-tooling": "https://github.com/angular/dev-infra-private-build-tooling-builds.git#5e30807f0fc6f1f00b2ac9186bd5f704b72e6ea6",
+-    "@angular/docs": "https://github.com/angular/dev-infra-private-docs-builds.git#97fa4e1998648d1c620113d8eb15a324ae7b20b3",
++    "@angular/docs": "https://github.com/angular/dev-infra-private-docs-builds.git#df9ea153749a054c2abbc72902aad5b21cb27d91",
+     "@angular/ng-dev": "https://github.com/angular/dev-infra-private-ng-dev-builds.git#806cbfc987d0df61f2ed90a24e2d4176e8a50a5b",
+     "@bazel/bazelisk": "^1.7.5",
+     "@bazel/buildifier": "^6.0.0",
+diff --git a/yarn.lock b/yarn.lock
+index d2896c0b9a..924dd4579d 100644
+--- a/yarn.lock
++++ b/yarn.lock
+@@ -471,18 +471,18 @@
+   dependencies:
+     tslib "^2.3.0"
+ 
+-"@angular/docs@https://github.com/angular/dev-infra-private-docs-builds.git#97fa4e1998648d1c620113d8eb15a324ae7b20b3":
+-  version "0.0.0-720be096e12c01c8346d7787e0931b184525b925"
+-  resolved "https://github.com/angular/dev-infra-private-docs-builds.git#97fa4e1998648d1c620113d8eb15a324ae7b20b3"
++"@angular/docs@https://github.com/angular/dev-infra-private-docs-builds.git#df9ea153749a054c2abbc72902aad5b21cb27d91":
++  version "0.0.0-3b9536b799d033fe6ab4437131c81c10c7bdd101"
++  resolved "https://github.com/angular/dev-infra-private-docs-builds.git#df9ea153749a054c2abbc72902aad5b21cb27d91"
+   dependencies:
+     "@webcontainer/api" "^1.1.8"
+     diff "~5.2.0"
+     emoji-regex "~10.3.0"
+     fast-glob "~3.3.2"
++    fflate "^0.8.2"
+     highlight.js "~11.9.0"
+     html-entities "~2.5.2"
+     jsdom "~24.1.0"
+-    jszip "~3.10.1"
+     marked "~12.0.2"
+     mermaid "^10.8.0"
+ 
+@@ -8472,6 +8472,11 @@ fecha@^4.2.0:
+   resolved "https://registry.yarnpkg.com/fecha/-/fecha-4.2.3.tgz#4d9ccdbc61e8629b259fdca67e65891448d569fd"
+   integrity sha512-OP2IUU6HeYKJi3i0z4A19kHMQoLVs4Hc+DPqqxI2h/DPZHTm/vjsfC6P0b4jCMy14XizLBqvndQ+UilD7707Jw==
+ 
++fflate@^0.8.2:
++  version "0.8.2"
++  resolved "https://registry.yarnpkg.com/fflate/-/fflate-0.8.2.tgz#fc8631f5347812ad6028bbe4a2308b2792aa1dea"
++  integrity sha512-cPJU47OaAoCbg0pBvzsgpTPhmhqI5eJjh/JIu8tPj5q+T7iLvW/JAYUqmE7KOB4R1ZyEhzBaIQpQpardBF5z8A==
++
+ figures@^3.0.0, figures@^3.2.0:
+   version "3.2.0"
+   resolved "https://registry.yarnpkg.com/figures/-/figures-3.2.0.tgz#625c18bd293c604dc4a8ddb2febf0c88341746af"
+@@ -10781,7 +10786,7 @@ jsprim@^1.2.2:
+     json-schema "0.4.0"
+     verror "1.10.0"
+ 
+-jszip@^3.1.3, jszip@^3.10.1, jszip@~3.10.1:
++jszip@^3.1.3, jszip@^3.10.1:
+   version "3.10.1"
+   resolved "https://registry.yarnpkg.com/jszip/-/jszip-3.10.1.tgz#34aee70eb18ea1faec2f589208a157d1feb091c2"
+   integrity sha512-xXDvecyTpGLrqFrvkrUSoxxfJI5AH7U8zxxtVclpsUtMCq4JQ290LY8AW5c7Ggnr/Y/oK+bQMbqK2qmtk3pN4g==


### PR DESCRIPTION
Temporary version resolution to preview #949 . Remove this patch when the origin includes it.