### PR TITLE
chore: re-add deployment to Firebase

### DIFF
--- a/.firebaserc
+++ b/.firebaserc
@@ -1,0 +1,5 @@
+{
+  "projects": {
+    "default": "angular-ja"
+  }
+}

--- a/.github/workflows/adev-production-deploy.yml
+++ b/.github/workflows/adev-production-deploy.yml
@@ -44,3 +44,10 @@ jobs:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ vars.CLOUDFLARE_ACCOUNT_ID }}
           CLOUDFLARE_PAGES_PROJECT: ${{ vars.CLOUDFLARE_PAGES_PROJECT }}
+      - name: Deploy to Firebase Hosting
+        uses: FirebaseExtended/action-hosting-deploy@v0.9.0
+        with:
+          repoToken: "${{ secrets.GITHUB_TOKEN }}"
+          firebaseServiceAccount: "${{ secrets.FIREBASE_SERVICE_ACCOUNT }}"
+          projectId: angular-ja
+          channelId: live

--- a/firebase.json
+++ b/firebase.json
@@ -1,0 +1,16 @@
+{
+    "hosting": {
+      "public": "build/dist/bin/adev/build/browser",
+      "ignore": [
+        "firebase.json",
+        "**/.*",
+        "**/node_modules/**"
+      ],
+      "rewrites": [
+        {
+          "source": "**",
+          "destination": "/index.html"
+        }
+      ]
+    }
+  }


### PR DESCRIPTION
Cloudflare Pagesの変更不可能なtrailing slash redirectの仕様がAngularのprerenderと相性が悪いため、Firebase Hostingへ戻すことを検討している。