### PR TITLE
chore: disable adding trailing slash by firebase hosting

### DIFF
--- a/firebase.json
+++ b/firebase.json
@@ -11,6 +11,7 @@
           "source": "**",
           "destination": "/index.html"
         }
-      ]
+      ],
+      "trailingSlash": false
     }
   }


### PR DESCRIPTION
https://firebase.google.com/docs/hosting/full-config?hl=ja

`/about/index.html` が存在するとき、 `/about` へのリクエストを自動的に `/about/` にリダイレクトする振る舞いを無効にする