### PR TITLE
docs: fix heading ID formatting in develop-with-ai.md

### DIFF
--- a/adev-ja/src/content/ai/develop-with-ai.md
+++ b/adev-ja/src/content/ai/develop-with-ai.md
@@ -31,7 +31,7 @@ Angular CLIには、開発環境のAIアシスタントがAngular CLIと連携�
 
 [**Angular CLI MCPサーバーのセットアップ方法を学ぶ**](/ai/mcp)
 
-## llms.txtによるコンテキスト提供 {#providing-context-with-llms.txt}
+## llms.txtによるコンテキスト提供 {#providing-context-with-llmstxt}
 `llms.txt`は、LLMがコンテンツをより良く理解し処理できるよう設計されたウェブサイト向けの提案されている標準です。Angularチームは、LLMおよびコード生成にLLMを使用するツールが、より良いモダンなAngularコードを作成できるようにするため、このファイルの2つのバージョンを開発しました。
 
 


### PR DESCRIPTION
## Summary

Fix heading ID formatting by removing dots from the anchor ID as per translator guidelines.

## Changes

- Fixed heading ID from `#providing-context-with-llms.txt` to `#providing-context-with-llmstxt` in `adev-ja/src/content/ai/develop-with-ai.md`

This follows the heading ID symbol handling rule that removes all symbols except hyphens from anchor IDs.