### PR TITLE
chore(ci): update bazel-contrib/setup-bazel to v0.15.0

### DIFF
--- a/.github/workflows/adev-preview-build.yml
+++ b/.github/workflows/adev-preview-build.yml
@@ -29,7 +29,7 @@ jobs:
         with:
           node-version-file: '.node-version'
           cache: pnpm
-      - uses: bazel-contrib/setup-bazel@e403ad507104847c3539436f64a9e9eecc73eeec # 0.8.5
+      - uses: bazel-contrib/setup-bazel@4fd964a13a440a8aeb0be47350db2fc640f19ca8 # 0.15.0
         with:
           bazelisk-cache: true
           disk-cache: true

--- a/.github/workflows/adev-production-deploy.yml
+++ b/.github/workflows/adev-production-deploy.yml
@@ -21,7 +21,7 @@ jobs:
         with:
           node-version-file: '.node-version'
           cache: pnpm
-      - uses: bazel-contrib/setup-bazel@e403ad507104847c3539436f64a9e9eecc73eeec # 0.8.5
+      - uses: bazel-contrib/setup-bazel@4fd964a13a440a8aeb0be47350db2fc640f19ca8 # 0.15.0
         with:
           bazelisk-cache: true
           disk-cache: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,7 @@ jobs:
         with:
           node-version-file: '.node-version'
           cache: pnpm
-      - uses: bazel-contrib/setup-bazel@0.15.0 # 0.15.0
+      - uses: bazel-contrib/setup-bazel@4fd964a13a440a8aeb0be47350db2fc640f19ca8 # 0.15.0
         with:
           bazelisk-cache: true
           disk-cache: true


### PR DESCRIPTION
## 翻訳・修正

変更内容は[CONTRIBUTING.md](https://github.com/angular/angular-ja/blob/main/CONTRIBUTING.md) に記載されたワークフローに従っていることを確認してください。

- [x] [翻訳のガイドライン](CONTRIBUTING.md#%E7%BF%BB%E8%A8%B3%E3%81%AE%E3%82%AC%E3%82%A4%E3%83%89%E3%83%A9%E3%82%A4%E3%83%B3)を確認しました。
- [x] 原文ファイルと翻訳ファイルの改行数が一致しています。

## 関連Issue

This PR updates the bazel-contrib/setup-bazel GitHub Action from v0.8.5 to v0.15.0 across all workflow files to ensure we're using the latest version with improved performance and bug fixes.

### 備考

This is a maintenance update to keep our CI workflows up-to-date with the latest bazel setup action version. The changes affect:
- `.github/workflows/adev-preview-build.yml`
- `.github/workflows/adev-production-deploy.yml` 
- `.github/workflows/ci.yml`