### PR TITLE
fix: correct styling for docs-viewer headings

### DIFF
--- a/tools/adev-patches/add-global-styles.patch
+++ b/tools/adev-patches/add-global-styles.patch
@@ -8,7 +8,7 @@ index 2c83a2ad4a..9d9b28112a 100644
  @include xterm.xterm();
 +// adev-ja overrides
 +
-+docs-viewer {
++.docs-viewer {
 +    // `balance` is not good for Japanese headings.
 +    h1,
 +    h2,


### PR DESCRIPTION
This pull request updates the global styles patch to correctly target the `.docs-viewer` class instead of the `docs-viewer` element, which improves the specificity and reliability of the style override for Japanese headings.

* Global Styles Correction:
  * Changed the selector from `docs-viewer` to `.docs-viewer` to ensure styles are applied to the intended class, addressing issues with heading balancing for Japanese content.