### PR TITLE
feat(tools): add list-untranslated script to identify untranslated files

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "test": "pnpm run test:patch",
     "test:patch": "git apply -v --check --directory origin ./tools/adev-patches/*.patch",
     "update-origin": "tsx tools/update-origin.ts",
+    "list-untranslated": "tsx tools/list-untranslated.ts",
     "translate": "tsx --env-file=.env tools/translator/main.ts"
   },
   "packageManager": "pnpm@10.15.0",

--- a/tools/list-untranslated.ts
+++ b/tools/list-untranslated.ts
@@ -1,0 +1,40 @@
+#!/usr/bin/env tsx
+
+/**
+ * @fileoverview Lists files in adev-ja that don't have corresponding .en.* backup files,
+ * indicating they haven't been translated yet.
+ */
+
+import { consola } from 'consola';
+import { extname, resolve } from 'node:path';
+import { exists, getEnFilePath, glob } from './lib/fsutils';
+import { adevJaDir } from './lib/workspace';
+
+async function main() {
+  const files = await glob(['**/*.{md,ts,html,json}', '!**/license.md'], {
+    cwd: adevJaDir,
+  });
+  const untranslated = [];
+
+  for (const file of files) {
+    const ext = extname(file);
+    if (file.includes(`.en${ext}`)) continue;
+    if (!(await exists(resolve(adevJaDir, getEnFilePath(file))))) {
+      untranslated.push(file);
+    }
+  }
+
+  untranslated.length
+    ? consola.info(
+        `Found ${untranslated.length} untranslated files:\n${untranslated
+          .sort()
+          .map((f) => `  ${f}`)
+          .join('\n')}`
+      )
+    : consola.success('All files translated! 🎉');
+}
+
+main().catch((error) => {
+  consola.error(error);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary

Add a new utility script `list-untranslated` that identifies files in adev-ja that don't have corresponding `.en.*` backup files, indicating they haven't been translated yet.

## Changes

- ✅ Add `tools/list-untranslated.ts` - New TypeScript executable script that scans for untranslated files
- ✅ Add `pnpm run list-untranslated` command to package.json for easy execution
- ✅ Uses simple glob pattern to find all translatable files (`.md`, `.ts`, `.html`, `.json`)
- ✅ Excludes license files and `.en.*` backup files from scan
- ✅ Provides clear output showing count and list of untranslated files

## Usage

```bash
pnpm run list-untranslated
```

Output example:
```
Found 149 untranslated files:
  src/content/best-practices/error-handling.md
  src/content/ecosystem/rxjs-interop/output-interop.md
  ...
```

This tool helps identify translation gaps and prioritize translation work.