### PR TITLE
fix(patch): add word-break auto-phrase to navigation list

### DIFF
--- a/tools/adev-patches/fix-navigation-list-style.patch
+++ b/tools/adev-patches/fix-navigation-list-style.patch
@@ -1,0 +1,12 @@
+diff --git a/adev/shared-docs/components/navigation-list/navigation-list.component.scss b/adev/shared-docs/components/navigation-list/navigation-list.component.scss
+index 5e0b7a90ac..f48f54cb7c 100644
+--- a/adev/shared-docs/components/navigation-list/navigation-list.component.scss
++++ b/adev/shared-docs/components/navigation-list/navigation-list.component.scss
+@@ -50,6 +50,7 @@
+     overflow: hidden;
+     text-overflow: ellipsis;
+     text-wrap: balance;
++    word-break: auto-phrase;
+   }
+ 
+   .docs-nav-item-has-icon {


### PR DESCRIPTION
## 概要

ナビゲーションリストのラベルに`word-break: auto-phrase`プロパティを追加し、日本語テキストの折り返しと可読性を向上させます。

## 変更内容

- `tools/adev-patches/fix-navigation-list-style.patch` を追加
  - `adev/shared-docs/components/navigation-list/navigation-list.component.scss`に`word-break: auto-phrase`を追加

## 動作確認

- [ ] patchが正しく適用されることを確認
- [ ] ナビゲーションリストの表示を目視確認

## 備考

`word-break: auto-phrase`は日本語テキストにおいて、より自然な位置で改行を行うためのCSS仕様です。