### PR TITLE
fix(tools): improve translator summary output formatting

### DIFF
--- a/tools/translator/main.ts
+++ b/tools/translator/main.ts
@@ -305,14 +305,23 @@ async function main() {
     await writeFile(errorLogPath, errorDetails, 'utf-8');
   }
 
-  consola.box(`
-翻訳完了
+  if (failed.length === 0) {
+    consola.success('翻訳完了');
+  } else {
+    consola.warn('翻訳完了（一部失敗）');
+  }
 
-成功: ${succeeded.length}件
-失敗: ${failed.length}件
-${failed.length > 0 ? '\n失敗したファイル:\n' + failed.map((r) => `  - ${r.file}`).join('\n') : ''}
-${errorLogPath ? `\nエラー詳細: ${errorLogPath}` : ''}
-  `);
+  consola.info(`成功: ${succeeded.length}件`);
+  consola.info(`失敗: ${failed.length}件`);
+
+  if (failed.length > 0) {
+    console.log('\n失敗したファイル:');
+    failed.forEach((r) => console.log(r.file));
+  }
+
+  if (errorLogPath) {
+    consola.info(`エラー詳細: ${errorLogPath}`);
+  }
 
   if (failed.length > 0) {
     process.exit(1);


### PR DESCRIPTION
## 概要

翻訳ツールの完了サマリー出力を改善しました。

## 変更内容

- `consola.box()` を標準のログメソッドに置き換え、全角・半角混在文字によるレイアウト崩れを解消
- 翻訳結果に応じて成功/警告ステータスを表示
- 失敗したファイルをコピーペースト可能なプレーンテキストで列挙

## 修正前の問題

`consola.box()` による出力でボックスの右側罫線が崩れていました（全角・半角混在による文字幅計算の問題）。

## 修正後

- 成功時: `✔ 翻訳完了`
- 失敗時: `⚠ 翻訳完了（一部失敗）`
- 失敗ファイルリスト: 装飾なしのプレーンテキストで表示（コピーペースト可能）