### PR TITLE
fix(ci): correct reference section preview URLs in sync-untranslated-issue script

### DIFF
--- a/.github/scripts/sync-untranslated-issue.mjs
+++ b/.github/scripts/sync-untranslated-issue.mjs
@@ -73,6 +73,14 @@ function generatePreviewPath(filepath) {
     .replace(/\/README\.md$/, '') // READMEの場合はディレクトリのみ
     .replace(/\.md$/, '');
 
+  // reference 配下の特殊なパス変換
+  if (basePath === 'reference/press-kit') {
+    return 'press-kit';
+  }
+  if (basePath === 'reference/roadmap') {
+    return 'roadmap';
+  }
+
   // チュートリアルの特殊なパス変換
   if (basePath.startsWith('tutorials/')) {
     // tutorials/first-app/intro -> tutorials/first-app


### PR DESCRIPTION
## 概要

`sync-untranslated-issue.mjs`のプレビューURL生成ロジックで、`reference`配下の特殊なURLパターンに対応しました。

## 変更内容

- `generatePreviewPath`関数に`reference/press-kit`と`reference/roadmap`の特殊ケース処理を追加
- `reference/press-kit` → `/press-kit`のURL変換を実装
- `reference/roadmap` → `/roadmap`のURL変換を実装

## 関連Issue

N/A (バグ修正)