### PR TITLE
refactor(tools): exclude reference/concepts/overview.md from localization

### DIFF
--- a/adev-ja/src/content/reference/concepts/overview.md
+++ b/adev-ja/src/content/reference/concepts/overview.md
@@ -1,7 +1,0 @@
-# Concepts
-
-<docs-card-container>
-  <docs-card title="NgModules" link="Learn more" href="guide/ngmodules">
-    NgModules is a concept that commonly used in architecture v16 and earlier to help configure the injector and the compiler and help organize related things together.
-  </docs-card>
-</docs-card-container>

--- a/tools/update-origin.ts
+++ b/tools/update-origin.ts
@@ -14,6 +14,7 @@ const localizedFilePatterns: Array<string | readonly string[]> = [
     '!src/content/kitchen-sink.md',
     '!src/content/examples/**/readme.md',
     '!src/content/tutorials/README.md',
+    '!src/content/reference/concepts/overview.md',
   ],
   // Tutorial config files
   'src/content/tutorials/**/config.json',


### PR DESCRIPTION
## 概要

`reference/concepts/overview.md`は翻訳対象ではないため、`update-origin`スクリプトのコピー対象から除外しました。

## 変更内容

- `tools/update-origin.ts`の`localizedFilePatterns`に`!src/content/reference/concepts/overview.md`を追加
- `adev-ja/src/content/reference/concepts/overview.md`を削除

## 関連Issue

N/A