### PR TITLE
fix(build): use local spawn strategy to allow network access during prerender

### DIFF
--- a/.bazelrc.user.example
+++ b/.bazelrc.user.example
@@ -1,0 +1,6 @@
+# Local development settings for macOS
+# Copy this file to .bazelrc.user to enable these settings.
+#
+# macOS sandbox blocks network access during prerendering (Algolia API calls).
+# Use local spawn strategy to allow network access.
+build --spawn_strategy=local

--- a/.github/workflows/adev-preview-build.yml
+++ b/.github/workflows/adev-preview-build.yml
@@ -47,7 +47,7 @@ jobs:
             common --color=yes
       - run: pnpm install --frozen-lockfile
       - run: pnpm run build
-      - uses: angular/dev-infra/github-actions/previews/pack-and-upload-artifact@01c8c16f830d02110c28640aea16f145a7937080
+      - uses: angular/dev-infra/github-actions/previews/pack-and-upload-artifact@0512a5b9381ccff00c278d7b4b6ee38e5c09654d
         with:
           workflow-artifact-name: 'adev-preview'
           pull-number: '${{ github.event.pull_request.number }}'

--- a/.github/workflows/adev-preview-deploy.yml
+++ b/.github/workflows/adev-preview-deploy.yml
@@ -29,7 +29,7 @@ jobs:
     if: ${{ github.event.workflow_run.conclusion == 'success' }}
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-      - uses: angular/dev-infra/github-actions/previews/upload-artifacts-to-firebase@01c8c16f830d02110c28640aea16f145a7937080
+      - uses: angular/dev-infra/github-actions/previews/upload-artifacts-to-firebase@0512a5b9381ccff00c278d7b4b6ee38e5c09654d
         with:
           github-token: '${{secrets.GITHUB_TOKEN}}'
           workflow-artifact-name: 'adev-preview'

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 .tmp
 .env
 .textlintcache
+.bazelrc.user
 build
 node_modules

--- a/tools/lib/setup.ts
+++ b/tools/lib/setup.ts
@@ -1,6 +1,6 @@
 import { consola } from 'consola';
 import { $ } from 'execa';
-import { mkdir } from 'node:fs/promises';
+import { appendFile, mkdir, readFile } from 'node:fs/promises';
 import { resolve } from 'node:path';
 import { cpRf, exists, rmrf } from './fsutils';
 import { applyPatches, copyLocalizedFiles } from './localize';
@@ -31,4 +31,10 @@ async function initBuildDir() {
   await mkdir(buildDir, { recursive: true });
   await cpRf(resolve(rootDir, 'origin'), buildDir);
   await cpRf(resolve(rootDir, '.bazelrc'), resolve(buildDir, '.bazelrc.user'));
+  // Append user's local bazelrc settings if exists
+  const userBazelrc = resolve(rootDir, '.bazelrc.user');
+  if (await exists(userBazelrc)) {
+    const content = await readFile(userBazelrc, 'utf-8');
+    await appendFile(resolve(buildDir, '.bazelrc.user'), '\n' + content);
+  }
 }


### PR DESCRIPTION
## Summary

- macOSのサンドボックスがプリレンダリング中のネットワークアクセスをブロックし、Algolia API呼び出しが失敗する問題を修正
- `--spawn_strategy=local`を`.bazelrc`に追加することで、ネットワークアクセスを許可

## 関連Issue

N/A

## 確認事項

- [x] `pnpm build`が成功することを確認