### PR TITLE
fix(docs): improve home page headline translations

### DIFF
--- a/adev-ja/src/app/features/home/home.component.html
+++ b/adev-ja/src/app/features/home/home.component.html
@@ -15,7 +15,7 @@
 
       @if (!isUwu) {
         <div class="title">
-          <h2>開発効率と<br />スケーラビリティの融合</h2>
+          <h2>Productivity<br />Meets scalability</h2>
           <h3>スケーラブルなWebアプリを確信を持って構築できるフレームワーク</h3>
         </div>
       } @else {
@@ -37,7 +37,7 @@
   </section>
 
   <section class="features-section">
-    <h2 id="features">問題解決に役立つ機能</h2>
+    <h2 id="features">あなたの問題解決を助ける<br />多くの機能</h2>
 
     <div ngTabs class="material-tabs">
       <div ngTabList selectionMode="follow" selectedTab="signals">
@@ -85,7 +85,7 @@
   </section>
 
   <section class="selling-points">
-    <h2>よりスマートに、より速い構築</h2>
+    <h2>よりスマートに、より速い開発を</h2>
     <div class="cards">
       <a class="card" routerLink="/ai/develop-with-ai">
         <div class="icon-wrapper">
@@ -141,7 +141,7 @@
     <div class="wrapper">
       <div class="pattern"></div>
       <div class="content">
-        <h2>パフォーマンスが重要な場面</h2>
+        <h2>パフォーマンスが問われる場面で</h2>
         <h3>
           チームの成長に合わせてスケールする高速で信頼性の高いアプリケーション構築。
           数百万の開発者が信頼
@@ -160,7 +160,7 @@
 
   <section class="explore-section" id="learn-more">
     <div class="title">
-      <h2>Angularについてもっと学ぶには</h2>
+      <h2>Angularの何を学ぶ？</h2>
       <div class="pattern"></div>
     </div>
 


### PR DESCRIPTION
## 翻訳チェックリスト

- [x] [翻訳ガイドライン](https://github.com/nicovalencia/angular-ja/blob/main/.github/translation-guide.md)を読んだ
- [x] 翻訳された文と原文の行数が一致している

## 関連Issue

N/A

## 備考

ホームページの見出し翻訳を改善:

- "Productivity Meets scalability" → 原文ママに変更
- "問題解決に役立つ機能" → "あなたの問題解決を本当に助ける機能"（actually, youを反映）
- "よりスマートに、より速い構築" → "よりスマートに、より速い開発を"（buildを「開発」に）
- "パフォーマンスが重要な場面" → "パフォーマンスが問われる場面で"（mattersのニュアンス）
- "Angularについてもっと学ぶには" → "Angularの何を学ぶ？"（Where/Whatの対比）