### PR TITLE
fix: run pnpm install before ibazel to ensure dependencies are available

### DIFF
--- a/tools/lib/adev.ts
+++ b/tools/lib/adev.ts
@@ -24,8 +24,10 @@ export async function buildAdev() {
   }
 }
 
-export function serveAdev() {
+export async function serveAdev() {
   const sh = $$({ cwd: buildDir, reject: false });
+  // Ensure dependencies are installed before running ibazel
+  await $$({ cwd: buildDir })`pnpm install --frozen-lockfile`;
   const p = sh`pnpm ibazel run //adev:build.serve`;
   const pid = p.pid!;
   consola.log(`adev process started: ${pid}`);

--- a/tools/watch.ts
+++ b/tools/watch.ts
@@ -35,7 +35,7 @@ async function watch() {
   const fileWatcher = watchLocalizedFiles();
 
   consola.start('Start adev server...');
-  const adevServer = serveAdev();
+  const adevServer = await serveAdev();
 
   const shutdown = () => {
     consola.info('Shutting down...');


### PR DESCRIPTION
## 概要

`pnpm start`実行時に「Command 'ibazel' not found」エラーが発生する問題を修正。

## 原因

`serveAdev()`が`ibazel`を直接呼び出す前に、`build`ディレクトリで`pnpm install`を実行していなかった。`@bazel/ibazel`はnpmパッケージとして提供されているため、`node_modules/.bin/ibazel`が存在しないと実行できない。

## 修正内容

- `serveAdev()`をasync関数に変更
- `ibazel run`の前に`pnpm install --frozen-lockfile`を実行
- `watch.ts`で`await serveAdev()`に修正