### PR TITLE
fix(build): unblock Algolia prerendering for CI and macOS local builds

### DIFF
--- a/.bazelrc.user.example
+++ b/.bazelrc.user.example
@@ -1,6 +1,10 @@
 # Local development settings for macOS
 # Copy this file to .bazelrc.user to enable these settings.
-#
 # macOS sandbox blocks network access during prerendering (Algolia API calls).
 # Use local spawn strategy to allow network access.
+#
+# macOS向けのローカル開発設定です。
+# このファイルを .bazelrc.user という名前でコピーすると有効になります。
+# macOSのBazel sandboxは、プレレンダリング中のネットワークアクセス（Algolia API呼び出し）を
+# ブロックするため、sandboxを使わないlocal spawn strategyに切り替えて回避します。
 build --spawn_strategy=local

--- a/.github/workflows/adev-preview-build.yml
+++ b/.github/workflows/adev-preview-build.yml
@@ -41,6 +41,8 @@ jobs:
             build --jobs=2
             build --discard_analysis_cache
             build --nokeep_state_after_build
+            # Allow network access in sandbox for Algolia API calls during SSR prerendering.
+            build --sandbox_default_allow_network
       - run: pnpm install --frozen-lockfile
       - name: Build
         run: pnpm run build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,6 +45,8 @@ jobs:
             build --jobs=2
             build --discard_analysis_cache
             build --nokeep_state_after_build
+            # Allow network access in sandbox for Algolia API calls during SSR prerendering.
+            build --sandbox_default_allow_network
       - run: pnpm install
       - name: Build
         run: pnpm run build

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -54,6 +54,14 @@ $ pnpm install
 $ pnpm build
 ```
 
+> [!IMPORTANT]
+> macOSでビルドする場合は、`pnpm build` を実行する前に `.bazelrc.user.example` を `.bazelrc.user` という名前でコピーしてください（`.bazelrc.user` は `.gitignore` 対象です）。
+> macOSのBazel sandboxがプレレンダリング中のネットワークアクセス（Algolia API呼び出し）をブロックするため、これがないとビルドが失敗します。
+>
+> ```
+> $ cp .bazelrc.user.example .bazelrc.user
+> ```
+
 ### 開発用サーバーを使った作業
 
 開発用ローカルサーバーを起動すると、ビルド結果を確認しながら翻訳作業ができます。


### PR DESCRIPTION
## 概要

Angular v22 アップデート (#1169) 以降、SSRプレレンダリング中に algoliasearch が Algolia API へアクセスするようになり、Bazel sandbox が network を遮断するため `pnpm build` が `RetryError: Unreachable hosts` で失敗するようになっていた。CI (build-ubuntu) もこれで継続的に失敗している。

本PRはこの問題を以下の3点で対処する。

## 変更内容

### 1. CI (`build-ubuntu` / `adev-preview-build`) の修正

`bazel-contrib/setup-bazel` の `bazelrc:` ブロックに `build --sandbox_default_allow_network` を追加し、CI 上で sandbox からの egress を許可する。`build/.bazelrc` 由来の `--nosandbox_default_allow_network` は home-tier の bazelrc で上書きされる。

### 2. macOS ローカル向け CONTRIBUTING.md 追記

`### 2. 初回のビルド` セクションに `> [!IMPORTANT]` コールアウトでmacOS向けの追加手順（`.bazelrc.user.example` → `.bazelrc.user` のコピー）を追記。

### 3. `.bazelrc.user.example` に日本語コメント併記

既存の英語コメントの下に日本語コメントを併記。

## 関連Issue

なし（#1137 / #1169 の続き）

### 備考

- macOS ローカルでは `.bazelrc.user.example` を `.bazelrc.user` にコピー後 `pnpm build` が完了することを実走確認済み
- CIは本PRのworkflow修正適用後にgreenになることを期待
