### PR TITLE
fix(robots): disallow /api/ from crawlers

### DIFF
--- a/tools/adev-patches/replace-robots.patch
+++ b/tools/adev-patches/replace-robots.patch
@@ -1,0 +1,13 @@
+diff --git a/adev/src/robots.txt b/adev/src/robots.txt
+index 20a871a810..8fd1157557 100644
+--- a/adev/src/robots.txt
++++ b/adev/src/robots.txt
+@@ -1,3 +1,6 @@
+-# Allow all URLs (see https://www.robotstxt.org/robotstxt.html)
++# Allow most URLs, disallow auto-generated English /api/ from crawlers.
++# /api/ is not localized (auto-generated from upstream Angular source).
+ User-agent: *
+-Disallow:
++Disallow: /api/
++
++Sitemap: https://angular.jp/sitemap.xml


### PR DESCRIPTION
## 翻訳・修正

変更内容は[CONTRIBUTING.md](https://github.com/angular/angular-ja/blob/main/CONTRIBUTING.md) に記載されたワークフローに従っていることを確認してください。

- [x] [翻訳のガイドライン](CONTRIBUTING.md#%E7%BF%BB%E8%A8%B3%E3%81%AE%E3%82%AC%E3%82%A4%E3%83%89%E3%83%A9%E3%82%A4%E3%83%B3)を確認しました。
- [x] 原文ファイルと翻訳ファイルの改行数が一致しています。

## 関連Issue

なし

### 備考

`/api/` は upstream の Angular ソースから自動生成される API リファレンスで、angular-ja では日本語化対象外（auto-generated、`localizedFilePatterns` の対象外）。

日本語サイトとしては SEO 価値がなく、検索クローラ (Bingbot/YandexBot/Amazonbot 等) によるクロールが Firebase Hosting の egress 増大の主要因になっていました。実測では Bingbot の `/api` 系トラフィックだけで 1 日あたり数百 MB を占めています。

robots.txt で `/api/` を Disallow に変更することで:
- 本物のクローラに対して `/api/` 配下のクロールを停止させ、Firebase egress を削減
- 検索結果からも `/api/` 配下のページが徐々にインデックスから外れていく（API リファレンスを検索したいユーザーは英語の angular.dev に誘導される想定）

#### 変更内容

`tools/adev-patches/replace-robots.patch` を追加し、upstream の `adev/src/robots.txt` を以下に置き換え:

```
# Allow most URLs, disallow auto-generated English /api/ from crawlers.
# /api/ is not localized (auto-generated from upstream Angular source).
User-agent: *
Disallow: /api/

Sitemap: https://angular.jp/sitemap.xml
```

`pnpm test` で patch が正常に apply されることを確認済み。